### PR TITLE
Import functions from lodash independently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+lib/

--- a/src/__tests__/cache.ts
+++ b/src/__tests__/cache.ts
@@ -997,6 +997,7 @@ describe('Cache', () => {
                         type: 'id',
                         id: 'bar',
                         generated: false,
+                        typename: "Bar"
                     },
                 },
                 bar: {
@@ -1039,6 +1040,7 @@ describe('Cache', () => {
                         type: 'id',
                         id: 'bar',
                         generated: false,
+                        typename: "Bar"
                     },
                 },
                 bar: {

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,4 +1,5 @@
-import { merge, cloneDeep } from 'lodash';
+import merge = require('lodash/merge');
+import cloneDeep = require('lodash/cloneDeep');
 import { Reducer } from 'redux';
 import {
     APOLLO_OVERWRITE,

--- a/src/reduxCache.ts
+++ b/src/reduxCache.ts
@@ -11,7 +11,7 @@ import {
     ReduxNormalizedCacheConfig,
     reduxNormalizedCacheFactory
 } from './reduxNormalizedCache';
-import {cloneDeep} from 'lodash';
+import cloneDeep = require('lodash/cloneDeep');
 
 export type ReduxCacheConfig = ApolloReducerConfig & ReduxNormalizedCacheConfig;
 


### PR DESCRIPTION
The current package is pulling in all of lodash as a dependency which can result in unnecessarily large bundle sizes. This change imports the functions independently instead. 

I've never used typescript before and this syntax seemed a little strange (`import ... = require(...)`) but I got it from this thread: https://github.com/lodash/lodash/issues/3192.

Happy to make adjustments if needed. 